### PR TITLE
Fix unzip of zip64 format data descriptions (>4GB files)

### DIFF
--- a/lib/unzip-stream.js
+++ b/lib/unzip-stream.js
@@ -206,11 +206,13 @@ UnzipStream.prototype._prepareOutStream = function (vars, entry) {
             }
             if (!compressedSizeMatches) { return; }
 
+            var dataDescriptorSize = vars.zip64 ? 24 : 16;
+
             self.state = states.FILE_DATA_END;
             if (self.data.length > 0) {
-                self.data = Buffer.concat([matchedChunk.slice(16), self.data]);
+                self.data = Buffer.concat([matchedChunk.slice(dataDescriptorSize), self.data]);
             } else {
-                self.data = matchedChunk.slice(16);
+                self.data = matchedChunk.slice(dataDescriptorSize);
             }
 
             return true;
@@ -311,12 +313,31 @@ UnzipStream.prototype._readExtraFields = function (data) {
 }
 
 UnzipStream.prototype._readDataDescriptor = function (data) {
+    // Try reading zip64 data descriptor (8 byte sizes)
+    // https://pkware.cachefly.net/webdocs/casestudies/APPNOTE.TXT 4.3.9.2
     var vars = binary.parse(data)
+        .word32lu('dataDescriptorSignature')
+        .word32lu('crc32')
+        .word64lu('compressedSize')
+        .word64lu('uncompressedSize')
+        .word32lu('nextHeader')
+        .vars;
+    
+    if (vars.nextHeader !== LOCAL_FILE_HEADER_SIG && vars.nextHeader !== CENTRAL_DIRECTORY_SIG) {
+        // Not a zip64 data descriptor, use 4 byte sizes
+        
+        vars = binary.parse(data)
         .word32lu('dataDescriptorSignature')
         .word32lu('crc32')
         .word32lu('compressedSize')
         .word32lu('uncompressedSize')
         .vars;
+        
+        vars['zip64'] = false;
+    } else {
+        delete vars['nextHeader'];
+        vars['zip64'] = true;
+    }
 
     return vars;
 }


### PR DESCRIPTION
The current unzip library does not support certain zip file formats (zip64 data descriptors) for >4GB files. This prevents full backups on full wallets from being restored successfully. The wallet errors: "incorrect password or file" after mostly unzipping the decrypted backup.